### PR TITLE
Most Wanted compatibility - added plushie blueprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -262,3 +262,4 @@ __pycache__/
 
 ##### CUSTOM #####
 *_backup_*.zip
+*.props

--- a/Assembler Needs Calculator/MDK/mdk.paths.props
+++ b/Assembler Needs Calculator/MDK/mdk.paths.props
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MDKVersion>1.2.31</MDKVersion>
-    <MDKGameBinPath>E:\SteamLibrary\SteamApps\common\SpaceEngineers\Bin64</MDKGameBinPath>
-    <MDKInstallPath>c:\users\julia\appdata\local\microsoft\visualstudio\15.0_f42d8490\extensions\5eef1sto.qic</MDKInstallPath>
-    <MDKOutputPath>C:\Users\julia\AppData\Roaming\SpaceEngineers\IngameScripts\local</MDKOutputPath>
+    <MDKVersion>1.4.13</MDKVersion>
+    <MDKGameBinPath>H:\SteamLibrary\SteamApps\common\SpaceEngineers\Bin64</MDKGameBinPath>
+    <MDKInstallPath>c:\users\wilki\appdata\local\microsoft\visualstudio\16.0_f3c76a75\extensions\wfwmepzv.2hp</MDKInstallPath>
+    <MDKOutputPath>C:\Users\wilki\AppData\Roaming\SpaceEngineers\IngameScripts\local</MDKOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Sandbox.Common">
@@ -66,6 +66,10 @@
     <Reference Include="MDKUtilities">
       <HintPath>$(MDKInstallPath)\MDKUtilities.dll</HintPath>
       <Private>true</Private>
+    </Reference>
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>$(MDKGameBinPath)\System.Collections.Immutable.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Analyzer Include="$(MDKInstallPath)\Analyzers\MDKAnalyzer.dll" />
   </ItemGroup>

--- a/BlockDefinitionExtractor/BlockDefinitionExtractor.py
+++ b/BlockDefinitionExtractor/BlockDefinitionExtractor.py
@@ -221,6 +221,7 @@ bpnames = {
     "Thrust": "ThrustComponent",
     "Reactor": "ReactorComponent",
     "SolarCell": "SolarCell",
+    "EngineerPlushie" : "EngineerPlushie",
     # Economy Components
     "ZoneChip": "ZoneChip",
 }

--- a/Projector2LCD/MDK/mdk.paths.props
+++ b/Projector2LCD/MDK/mdk.paths.props
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MDKVersion>1.2.31</MDKVersion>
-    <MDKGameBinPath>E:\SteamLibrary\SteamApps\common\SpaceEngineers\Bin64</MDKGameBinPath>
-    <MDKInstallPath>c:\users\julia\appdata\local\microsoft\visualstudio\15.0_f42d8490\extensions\5eef1sto.qic</MDKInstallPath>
-    <MDKOutputPath>C:\Users\julia\AppData\Roaming\SpaceEngineers\IngameScripts\local</MDKOutputPath>
+    <MDKVersion>1.4.13</MDKVersion>
+    <MDKGameBinPath>H:\SteamLibrary\SteamApps\common\SpaceEngineers\Bin64</MDKGameBinPath>
+    <MDKInstallPath>c:\users\wilki\appdata\local\microsoft\visualstudio\16.0_f3c76a75\extensions\wfwmepzv.2hp</MDKInstallPath>
+    <MDKOutputPath>C:\Users\wilki\AppData\Roaming\SpaceEngineers\IngameScripts\local</MDKOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Sandbox.Common">
@@ -66,6 +66,10 @@
     <Reference Include="MDKUtilities">
       <HintPath>$(MDKInstallPath)\MDKUtilities.dll</HintPath>
       <Private>true</Private>
+    </Reference>
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>$(MDKGameBinPath)\System.Collections.Immutable.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Analyzer Include="$(MDKInstallPath)\Analyzers\MDKAnalyzer.dll" />
   </ItemGroup>

--- a/ProjectorResourceBuilder/MDK/mdk.paths.props
+++ b/ProjectorResourceBuilder/MDK/mdk.paths.props
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MDKVersion>1.2.31</MDKVersion>
-    <MDKGameBinPath>E:\SteamLibrary\SteamApps\common\SpaceEngineers\Bin64</MDKGameBinPath>
-    <MDKInstallPath>c:\users\julia\appdata\local\microsoft\visualstudio\15.0_f42d8490\extensions\5eef1sto.qic</MDKInstallPath>
-    <MDKOutputPath>C:\Users\julia\AppData\Roaming\SpaceEngineers\IngameScripts\local</MDKOutputPath>
+    <MDKVersion>1.4.13</MDKVersion>
+    <MDKGameBinPath>H:\SteamLibrary\SteamApps\common\SpaceEngineers\Bin64</MDKGameBinPath>
+    <MDKInstallPath>c:\users\wilki\appdata\local\microsoft\visualstudio\16.0_f3c76a75\extensions\wfwmepzv.2hp</MDKInstallPath>
+    <MDKOutputPath>C:\Users\wilki\AppData\Roaming\SpaceEngineers\IngameScripts\local</MDKOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Sandbox.Common">
@@ -66,6 +66,10 @@
     <Reference Include="MDKUtilities">
       <HintPath>$(MDKInstallPath)\MDKUtilities.dll</HintPath>
       <Private>true</Private>
+    </Reference>
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>$(MDKGameBinPath)\System.Collections.Immutable.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Analyzer Include="$(MDKInstallPath)\Analyzers\MDKAnalyzer.dll" />
   </ItemGroup>


### PR DESCRIPTION
The new plushie caused an exit with the error: Mods that add new building components are currently not supported!.

- Added "EngineerPlushie" to bpnames