### PR TITLE
Give useful error with unknown blocks

### DIFF
--- a/Projector2LCD/Program.cs
+++ b/Projector2LCD/Program.cs
@@ -360,6 +360,12 @@ namespace IngameScript
 
         public Dictionary<string, int> GetComponents(string definition)
         {
+            if (!blueprints.ContainsKey(definition))
+            {
+                string errorText = "Unknown Blocks in Blueprint. Go to https://github.com/Juggernaut93/Projector2Assembler, and follow instructions for BlockDefinitionExtractor.";
+                WriteToAll(errorText);
+                throw new Exception(errorText);
+            }
             return blueprints[definition];
         }
 

--- a/ProjectorResourceBuilder/Program.cs
+++ b/ProjectorResourceBuilder/Program.cs
@@ -79,6 +79,10 @@ namespace IngameScript
 
         public Dictionary<string, int> GetComponents(string definition)
         {
+            if (!blueprints.ContainsKey(definition))
+            {
+                throw new Exception("Unknown Blocks in Blueprint. Go to https://github.com/Juggernaut93/Projector2Assembler, and follow instructions for BlockDefinitionExtractor.");
+            }
             return blueprints[definition];
         }
 


### PR DESCRIPTION
Fix for https://github.com/Juggernaut93/Projector2Assembler/issues/4. Now gives useful error text on LCDs and stack dump.

Note, I've updated issue with steps to reproduce problem.